### PR TITLE
CU-86b2cbgd5: Added Hook to Remove Inquiry Responses

### DIFF
--- a/app/src/database/models/inquiry.ts
+++ b/app/src/database/models/inquiry.ts
@@ -32,6 +32,18 @@ const InquirySchema: Schema = new mongoose.Schema(
   { timestamps: true },
 );
 
+// A pre-hook to delete all responses when an inquiry is deleted so that orphaned responses are not left behind.
+InquirySchema.pre(
+  'deleteOne',
+  { document: false, query: true },
+  async function () {
+    const doc = await this.model.findOne(this.getFilter());
+    if (doc) {
+      await InquiryResponse.deleteMany({ _id: { $in: doc.responses } });
+    }
+  },
+);
+
 export const Inquiry = mongoose.model<InquiryObject>('Inquiry', InquirySchema);
 export const InquiryResponse = mongoose.model<InquiryObject>(
   'InquiryResponse',


### PR DESCRIPTION
## Description 📝

This PR introduces a deleteOne pre-hook to the inquiry so that all inquiry responses are deleted to avoid orphaned data.

## How Has This Been Tested? 🔍

- [x] Deleted an inquiry without responses.
- [x] Deleted an inquiry without responses with several responses and verified they were all removed.

## Motivation and Context 🎯

Ensure there is higher data integrity so we do not store orphaned data.

## ClickUp Task 📌
[CU-86b2cbgd5](https://app.clickup.com/t/86b2cbgd5)