### PR TITLE
CU-69426 Link inquiry responses to threads

### DIFF
--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -1,0 +1,163 @@
+name: Deploy Script 🚀
+
+on:
+  workflow_dispatch:
+    inputs:
+      script_name:
+        description: 'Select migration script to deploy'
+        required: true
+        type: choice
+        options:
+          - 'migrate-inquiry-threads'
+      environment:
+        description: 'Target environment'
+        required: true
+        type: choice
+        default: 'production'
+        options:
+          - 'development'
+          - 'production'
+      dry_run:
+        description: 'Perform a dry run (preview changes only)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-script:
+    name: Deploy Migration Script
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: 'Checkout GitHub Action'
+        uses: actions/checkout@main
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          cache-dependency-path: './pnpm-lock.yaml'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get SSM Parameters
+        id: get-ssm-parameters
+        env:
+          AWS_REGION: us-east-1
+        run: |
+          MONGODB_URL=$(aws ssm get-parameter --name MONGODB_CONNECTION_STRING --with-decryption --query 'Parameter.Value' | tr -d '"')
+          MONGODB_USER=$(aws ssm get-parameter --name MONGODB_USER --with-decryption --query 'Parameter.Value' | tr -d '"')
+          MONGODB_PASSWORD=$(aws ssm get-parameter --name MONGODB_PASSWORD --with-decryption --query 'Parameter.Value' | tr -d '"')
+
+          echo "MONGODB_URL=$MONGODB_URL" >> $GITHUB_ENV
+          echo "MONGODB_USER=$MONGODB_USER" >> $GITHUB_ENV
+          echo "MONGODB_PASSWORD=$MONGODB_PASSWORD" >> $GITHUB_ENV
+
+      - name: Get the public IP of this runner
+        id: get_gh_runner_ip
+        shell: bash
+        run: |
+          echo "ip_address=$(curl https://checkip.amazonaws.com)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup MongoDB Atlas cli
+        uses: mongodb/atlas-github-action@v0.2.1
+
+      - name: Add runner IP to MongoDB access list
+        shell: bash
+        env:
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${{ secrets.MONGODB_ATLAS_PUBLIC_API_KEY }}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${{ secrets.MONGODB_ATLAS_PRIVATE_API_KEY }}
+          MONGODB_ATLAS_PROJECT_ID: ${{ secrets.MONGODB_ATLAS_PROJECT_ID }}
+        run: |
+          atlas accessLists create ${{ steps.get_gh_runner_ip.outputs.ip_address }} --type ipAddress --projectId $MONGODB_ATLAS_PROJECT_ID --comment "GitHub Actions Script Runner"
+
+      - name: Wait for MongoDB access list to update
+        shell: bash
+        run: |
+          sleep 30
+
+      - name: Validate Script Selection
+        run: |
+          echo "🎯 Selected script: ${{ inputs.script_name }}"
+          echo "🌍 Target environment: ${{ inputs.environment }}"
+          echo "🔍 Dry run mode: ${{ inputs.dry_run }}"
+
+          # Check if script file exists in scripts directory
+          if [ ! -f "scripts/${{ inputs.script_name }}.ts" ]; then
+            echo "❌ Script file 'scripts/${{ inputs.script_name }}.ts' not found"
+            exit 1
+          fi
+          
+          echo "✅ Script validation passed"
+
+      - name: Run Migration Script (Dry Run)
+        if: ${{ inputs.dry_run == true }}
+        run: |
+          echo "🔍 Running dry run for script: ${{ inputs.script_name }}"
+          echo "Executing in dry run mode (no changes will be applied)..."
+          pnpm run db:script
+        env:
+          NODE_ENV: ${{ inputs.environment }}
+          SCRIPT: "scripts/${{ inputs.script_name }}"
+          MONGODB_URL: ${{ env.MONGODB_URL }}
+          MONGODB_USER: ${{ env.MONGODB_USER }}
+          MONGODB_PASSWORD: ${{ env.MONGODB_PASSWORD }}
+
+      - name: Run Migration Script
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          echo "🚀 Executing script: ${{ inputs.script_name }}"
+          echo "Applying changes to database..."
+          pnpm run db:script -- --apply
+          echo "✅ Script execution completed successfully"
+        env:
+          NODE_ENV: ${{ inputs.environment }}
+          SCRIPT: "scripts/${{ inputs.script_name }}"
+          MONGODB_URL: ${{ env.MONGODB_URL }}
+          MONGODB_USER: ${{ env.MONGODB_USER }}
+          MONGODB_PASSWORD: ${{ env.MONGODB_PASSWORD }}
+
+      - name: Post-execution Summary
+        if: always()
+        run: |
+          echo "📊 Execution Summary"
+          echo "==================="
+          echo "Script: ${{ inputs.script_name }}"
+          echo "Environment: ${{ inputs.environment }}"
+          echo "Dry Run: ${{ inputs.dry_run }}"
+          echo "Status: ${{ job.status }}"
+          echo "Timestamp: $(date -u)"
+
+      - name: Remove runner IP from MongoDB access list
+        if: always()
+        shell: bash
+        env:
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${{ secrets.MONGODB_ATLAS_PUBLIC_API_KEY }}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${{ secrets.MONGODB_ATLAS_PRIVATE_API_KEY }}
+          MONGODB_ATLAS_PROJECT_ID: ${{ secrets.MONGODB_ATLAS_PROJECT_ID }}
+        run: |
+          atlas accessLists delete ${{ steps.get_gh_runner_ip.outputs.ip_address }} --projectId $MONGODB_ATLAS_PROJECT_ID --force
+
+      - name: Notify on Failure
+        if: failure()
+        run: |
+          echo "❌ Script execution failed!"
+          echo "Please check the logs above for error details."
+          echo "Script: ${{ inputs.script_name }}"
+          echo "Environment: ${{ inputs.environment }}"

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -103,7 +103,7 @@ jobs:
             echo "❌ Script file 'scripts/${{ inputs.script_name }}.ts' not found"
             exit 1
           fi
-          
+
           echo "✅ Script validation passed"
 
       - name: Run Migration Script (Dry Run)
@@ -114,7 +114,7 @@ jobs:
           pnpm run db:script
         env:
           NODE_ENV: ${{ inputs.environment }}
-          SCRIPT: "scripts/${{ inputs.script_name }}"
+          SCRIPT: 'scripts/${{ inputs.script_name }}'
           MONGODB_URL: ${{ env.MONGODB_URL }}
           MONGODB_USER: ${{ env.MONGODB_USER }}
           MONGODB_PASSWORD: ${{ env.MONGODB_PASSWORD }}
@@ -128,7 +128,7 @@ jobs:
           echo "✅ Script execution completed successfully"
         env:
           NODE_ENV: ${{ inputs.environment }}
-          SCRIPT: "scripts/${{ inputs.script_name }}"
+          SCRIPT: 'scripts/${{ inputs.script_name }}'
           MONGODB_URL: ${{ env.MONGODB_URL }}
           MONGODB_USER: ${{ env.MONGODB_USER }}
           MONGODB_PASSWORD: ${{ env.MONGODB_PASSWORD }}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "db:import": "tsx seed/import.ts",
     "db:export": "tsx seed/export.ts",
     "db:clean": "tsx seed/clean.ts",
+    "db:script": "tsx seed/${SCRIPT}.ts",
     "migrate:inquiry-threads": "tsx scripts/migrate-inquiry-threads.ts",
     "codegen": "graphql-codegen --config codegen.ts"
   },

--- a/package.json
+++ b/package.json
@@ -84,6 +84,5 @@
     "tsx": "^4.20.3",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.0"
-  },
-  "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/lib-storage": "^3.859.0",
     "@aws-sdk/s3-request-presigner": "^3.859.0",
     "@clerk/backend": "^2.6.2",
+    "@eslint/js": "^9.32.0",
     "@fastify/cors": "^11.1.0",
     "@graphql-tools/schema": "^10.0.25",
     "@graphql-tools/utils": "^10.9.1",
@@ -84,5 +85,5 @@
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.0"
   },
-  "packageManager": "pnpm@9.15.1+sha512.1acb565e6193efbebda772702950469150cf12bcc764262e7587e71d19dc98a423dff9536e57ea44c49bdf790ff694e83c27be5faa23d67e0c033b583be4bfcf"
+  "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad"
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "db:import": "tsx seed/import.ts",
     "db:export": "tsx seed/export.ts",
     "db:clean": "tsx seed/clean.ts",
+    "migrate:inquiry-threads": "tsx scripts/migrate-inquiry-threads.ts",
     "codegen": "graphql-codegen --config codegen.ts"
   },
   "engines": {
@@ -81,5 +82,6 @@
     "tsx": "^4.20.3",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.0"
-  }
+  },
+  "packageManager": "pnpm@9.15.1+sha512.1acb565e6193efbebda772702950469150cf12bcc764262e7587e71d19dc98a423dff9536e57ea44c49bdf790ff694e83c27be5faa23d67e0c033b583be4bfcf"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@clerk/backend':
         specifier: ^2.6.2
         version: 2.6.2(react@18.3.1)
+      '@eslint/js':
+        specifier: ^9.32.0
+        version: 9.32.0
       '@fastify/cors':
         specifier: ^11.1.0
         version: 11.1.0
@@ -9305,7 +9308,7 @@ snapshots:
   axios@1.7.4(debug@4.4.1):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.1)
-      form-data: 4.0.0
+      form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -10571,7 +10574,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.7.4(debug@4.4.1))
+      retry-axios: 2.6.0(axios@1.7.4)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -12124,7 +12127,7 @@ snapshots:
 
   ret@0.5.0: {}
 
-  retry-axios@2.6.0(axios@1.7.4(debug@4.4.1)):
+  retry-axios@2.6.0(axios@1.7.4):
     dependencies:
       axios: 1.7.4(debug@4.4.1)
 

--- a/scripts/migrate-inquiry-threads.ts
+++ b/scripts/migrate-inquiry-threads.ts
@@ -1,17 +1,17 @@
 /**
  * Migration Runner Script for Inquiry Thread Migration
- * 
+ *
  * This script runs the inquiry thread migration to populate missing inquiryId values
  * in threads that have direct relationships with InquiryResponse documents.
- * 
+ *
  * Usage:
  *   npm run migrate:inquiry-threads          # Dry run only
  *   npm run migrate:inquiry-threads --apply  # Apply changes
  */
 
-import { 
-  migrateInquiryThreads, 
-  validateThreadInquiryRelationships 
+import {
+  migrateInquiryThreads,
+  validateThreadInquiryRelationships,
 } from '../src/database/migrations/migrate-inquiry-threads';
 import database from '../src/database';
 import log from '../src/log';
@@ -32,98 +32,106 @@ async function main() {
     // Step 1: Validate current state
     log.info({ message: 'Current State Validation' });
     const validation = await validateThreadInquiryRelationships();
-    
-    log.info({ 
+
+    log.info({
       message: 'Thread validation results',
       totalThreads: validation.totalThreads,
       threadsWithInquiryId: validation.threadsWithInquiryId,
       threadsWithMissingInquiryId: validation.threadsWithMissingInquiryId,
       threadsWithInquiryResponses: validation.threadsWithInquiryResponses,
-      orphanedThreads: validation.orphanedThreads
+      orphanedThreads: validation.orphanedThreads,
     });
-    
+
     if (validation.inconsistentRelationships.length > 0) {
-      log.warn({ 
+      log.warn({
         message: 'Inconsistent relationships found',
-        inconsistentRelationships: validation.inconsistentRelationships
+        inconsistentRelationships: validation.inconsistentRelationships,
       });
     }
 
     // Step 2: Run migration
     log.info({ message: `${isDryRun ? 'Dry Run' : 'Applying'} Migration` });
-    
+
     const migrationResult = await migrateInquiryThreads(isDryRun);
-    
-    log.info({ 
+
+    log.info({
       message: 'Migration Results',
       totalThreadsChecked: migrationResult.totalThreadsChecked,
       threadsWithMissingInquiryId: migrationResult.threadsWithMissingInquiryId,
       threadsWithInquiryResponses: migrationResult.threadsWithInquiryResponses,
-      migratedOrWouldMigrate: isDryRun ? migrationResult.threadsWithInquiryResponses : migrationResult.successfulMigrations,
-      skippedThreads: migrationResult.skippedThreads
+      migratedOrWouldMigrate: isDryRun
+        ? migrationResult.threadsWithInquiryResponses
+        : migrationResult.successfulMigrations,
+      skippedThreads: migrationResult.skippedThreads,
     });
-    
+
     if (migrationResult.errors.length > 0) {
-      log.error({ 
+      log.error({
         message: 'Errors encountered during migration',
-        errors: migrationResult.errors
+        errors: migrationResult.errors,
       });
     }
 
     // Step 3: Final validation (if changes were applied)
     if (!isDryRun && migrationResult.successfulMigrations > 0) {
       log.info({ message: 'Post-Migration Validation' });
-      
+
       const postValidation = await validateThreadInquiryRelationships();
-      log.info({ 
+      log.info({
         message: 'Post-migration validation results',
-        remainingThreadsMissingInquiryId: postValidation.threadsWithMissingInquiryId,
-        threadsFixed: validation.threadsWithMissingInquiryId - postValidation.threadsWithMissingInquiryId
+        remainingThreadsMissingInquiryId:
+          postValidation.threadsWithMissingInquiryId,
+        threadsFixed:
+          validation.threadsWithMissingInquiryId -
+          postValidation.threadsWithMissingInquiryId,
       });
     }
 
     // Step 4: Summary and next steps
     log.info({ message: 'Migration Complete' });
-    
+
     if (isDryRun) {
       log.info({ message: 'This was a DRY RUN - no changes were made.' });
       if (migrationResult.threadsWithInquiryResponses > 0) {
-        log.info({ 
+        log.info({
           message: 'Migration plan ready',
           nextSteps: [
             'Review the migration plan above',
             'Create a database backup',
-            'Run with --apply flag to execute the migration'
-          ]
+            'Run with --apply flag to execute the migration',
+          ],
         });
       } else {
-        log.info({ message: 'No migration needed - all threads already have proper inquiryId values.' });
+        log.info({
+          message:
+            'No migration needed - all threads already have proper inquiryId values.',
+        });
       }
     } else {
-      log.info({ 
+      log.info({
         message: 'Migration completed successfully',
         threadsUpdated: migrationResult.successfulMigrations,
         nextSteps: [
           'Verify token usage calculations are now accurate',
           'Test inquiry analysis features',
-          'Monitor for any issues in production'
-        ]
+          'Monitor for any issues in production',
+        ],
       });
-      
+
       if (validation.orphanedThreads > 0) {
-        log.info({ 
+        log.info({
           message: 'Note: Some threads remain without inquiryId',
           orphanedThreads: validation.orphanedThreads,
-          reason: 'These are likely from agent playground or other non-inquiry contexts. This is expected and normal.'
+          reason:
+            'These are likely from agent playground or other non-inquiry contexts. This is expected and normal.',
         });
       }
     }
-
   } catch (error) {
     log.error({
       message: 'Migration script failed',
       error: error instanceof Error ? error.message : 'Unknown error',
-      stack: error instanceof Error ? error.stack : undefined
+      stack: error instanceof Error ? error.stack : undefined,
     });
     process.exit(1);
   } finally {
@@ -134,19 +142,19 @@ async function main() {
 
 // Handle uncaught errors
 process.on('unhandledRejection', (reason, promise) => {
-  log.error({ 
+  log.error({
     message: 'Unhandled Rejection',
     reason: reason,
-    promise: promise
+    promise: promise,
   });
   process.exit(1);
 });
 
 process.on('uncaughtException', (error) => {
-  log.error({ 
+  log.error({
     message: 'Uncaught Exception',
     error: error.message,
-    stack: error.stack
+    stack: error.stack,
   });
   process.exit(1);
 });

--- a/scripts/migrate-inquiry-threads.ts
+++ b/scripts/migrate-inquiry-threads.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env ts-node
+/**
+ * Migration Runner Script for Inquiry Thread Migration
+ * 
+ * This script runs the inquiry thread migration to populate missing inquiryId values
+ * in threads that have direct relationships with InquiryResponse documents.
+ * 
+ * Usage:
+ *   npm run migrate:inquiry-threads          # Dry run only
+ *   npm run migrate:inquiry-threads --apply  # Apply changes
+ */
+
+import { 
+  migrateInquiryThreads, 
+  validateThreadInquiryRelationships 
+} from '../src/database/migrations/migrate-inquiry-threads';
+import database from '../src/database';
+import log from '../src/log';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const shouldApply = args.includes('--apply');
+  const isDryRun = !shouldApply;
+
+  try {
+    console.log('🚀 Starting Inquiry Thread Migration');
+    console.log(`Mode: ${isDryRun ? 'DRY RUN' : 'APPLY CHANGES'}`);
+    console.log('=====================================\n');
+
+    // Initialize database connection
+    await database.init();
+    log.info({ message: 'Database connection established' });
+
+    // Step 1: Validate current state
+    console.log('📊 Current State Validation');
+    console.log('---------------------------');
+    const validation = await validateThreadInquiryRelationships();
+    
+    console.log(`Total threads: ${validation.totalThreads}`);
+    console.log(`Threads with inquiryId: ${validation.threadsWithInquiryId}`);
+    console.log(`Threads missing inquiryId: ${validation.threadsWithMissingInquiryId}`);
+    console.log(`Threads with InquiryResponses (can be migrated): ${validation.threadsWithInquiryResponses}`);
+    console.log(`Orphaned threads (no InquiryResponse): ${validation.orphanedThreads}`);
+    
+    if (validation.inconsistentRelationships.length > 0) {
+      console.log('\n⚠️  Inconsistent relationships found:');
+      validation.inconsistentRelationships.forEach(rel => console.log(`  - ${rel}`));
+    }
+
+    // Step 2: Run migration
+    console.log(`\n🔄 ${isDryRun ? 'Dry Run' : 'Applying'} Migration`);
+    console.log('---------------------------');
+    
+    const migrationResult = await migrateInquiryThreads(isDryRun);
+    
+    console.log(`\n📈 Migration Results:`);
+    console.log(`Total threads checked: ${migrationResult.totalThreadsChecked}`);
+    console.log(`Threads with missing inquiryId: ${migrationResult.threadsWithMissingInquiryId}`);
+    console.log(`Threads with InquiryResponses: ${migrationResult.threadsWithInquiryResponses}`);
+    console.log(`${isDryRun ? 'Would migrate' : 'Successfully migrated'}: ${isDryRun ? migrationResult.threadsWithInquiryResponses : migrationResult.successfulMigrations}`);
+    console.log(`Skipped threads: ${migrationResult.skippedThreads}`);
+    
+    if (migrationResult.errors.length > 0) {
+      console.log('\n❌ Errors encountered:');
+      migrationResult.errors.forEach(error => console.log(`  - ${error}`));
+    }
+
+    // Step 3: Final validation (if changes were applied)
+    if (!isDryRun && migrationResult.successfulMigrations > 0) {
+      console.log('\n🔍 Post-Migration Validation');
+      console.log('----------------------------');
+      
+      const postValidation = await validateThreadInquiryRelationships();
+      console.log(`Remaining threads missing inquiryId: ${postValidation.threadsWithMissingInquiryId}`);
+      console.log(`Migration reduced missing inquiryId threads by: ${validation.threadsWithMissingInquiryId - postValidation.threadsWithMissingInquiryId}`);
+    }
+
+    // Step 4: Summary and next steps
+    console.log('\n✅ Migration Complete');
+    console.log('====================');
+    
+    if (isDryRun) {
+      console.log('This was a DRY RUN - no changes were made.');
+      if (migrationResult.threadsWithInquiryResponses > 0) {
+        console.log(`\n📋 Next Steps:`);
+        console.log(`1. Review the migration plan above`);
+        console.log(`2. Create a database backup`);
+        console.log(`3. Run with --apply flag to execute the migration:`);
+        console.log(`   npm run migrate:inquiry-threads --apply`);
+      } else {
+        console.log('\n🎉 No migration needed - all threads already have proper inquiryId values.');
+      }
+    } else {
+      console.log(`✨ Successfully migrated ${migrationResult.successfulMigrations} threads!`);
+      console.log('\n📋 Recommended Next Steps:');
+      console.log('1. Verify token usage calculations are now accurate');
+      console.log('2. Test inquiry analysis features');
+      console.log('3. Monitor for any issues in production');
+      
+      if (validation.orphanedThreads > 0) {
+        console.log(`\n📝 Note: ${validation.orphanedThreads} threads remain without inquiryId.`);
+        console.log('These are likely from agent playground or other non-inquiry contexts.');
+        console.log('This is expected and normal.');
+      }
+    }
+
+  } catch (error) {
+    console.error('\n💥 Migration failed:', error);
+    log.error({
+      message: 'Migration script failed',
+      error: error instanceof Error ? error.message : 'Unknown error',
+      stack: error instanceof Error ? error.stack : undefined
+    });
+    process.exit(1);
+  } finally {
+    // Close database connection
+    process.exit(0);
+  }
+}
+
+// Handle uncaught errors
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('Unhandled Rejection at:', promise, 'reason:', reason);
+  process.exit(1);
+});
+
+process.on('uncaughtException', (error) => {
+  console.error('Uncaught Exception:', error);
+  process.exit(1);
+});
+
+// Run the migration
+main();

--- a/src/database/migrations/migrate-inquiry-threads.ts
+++ b/src/database/migrations/migrate-inquiry-threads.ts
@@ -1,0 +1,341 @@
+import database from '../index';
+import { Thread } from '../models/message';
+import { Inquiry, InquiryResponse } from '../models/inquiry';
+import log from '@/log';
+
+interface MigrationResult {
+  totalThreadsChecked: number;
+  threadsWithMissingInquiryId: number;
+  threadsWithInquiryResponses: number;
+  successfulMigrations: number;
+  skippedThreads: number;
+  errors: string[];
+  migrationsByInquiry: Record<string, number>; // inquiry title -> count of migrated threads
+}
+
+/**
+ * Migrates threads to include inquiryId based on direct InquiryResponse relationships.
+ * This migration only handles threads that have a direct, verifiable connection to an inquiry
+ * through an InquiryResponse document.
+ * 
+ * Safe Migration Strategy:
+ * 1. Find threads with missing inquiryId
+ * 2. Find InquiryResponse documents that reference these threads
+ * 3. Find Inquiry documents that contain these responses
+ * 4. Update threads with the correct inquiryId
+ * 
+ * @param dryRun - If true, only reports what would be migrated without making changes
+ * @returns Migration results summary
+ */
+export async function migrateInquiryThreads(dryRun: boolean = true): Promise<MigrationResult> {
+  const result: MigrationResult = {
+    totalThreadsChecked: 0,
+    threadsWithMissingInquiryId: 0,
+    threadsWithInquiryResponses: 0,
+    successfulMigrations: 0,
+    skippedThreads: 0,
+    errors: [],
+    migrationsByInquiry: {}
+  };
+
+  try {
+    // Step 1: Find all threads with missing inquiryId
+    const threadsWithMissingInquiryId = await Thread.find({
+      $or: [
+        { inquiryId: { $exists: false } },
+        { inquiryId: null },
+        { inquiryId: undefined }
+      ]
+    });
+
+    result.totalThreadsChecked = await Thread.countDocuments();
+    result.threadsWithMissingInquiryId = threadsWithMissingInquiryId.length;
+
+    // Step 2: Process threads with missing inquiryId (parallelized with controlled concurrency)
+    const BATCH_SIZE = 10; // Process 10 threads concurrently to avoid overwhelming the database
+    const threadBatches: typeof threadsWithMissingInquiryId[] = [];
+    
+    // Split threads into batches for parallel processing
+    for (let i = 0; i < threadsWithMissingInquiryId.length; i += BATCH_SIZE) {
+      threadBatches.push(threadsWithMissingInquiryId.slice(i, i + BATCH_SIZE));
+    }
+
+    // Process each batch in parallel
+    for (let batchIndex = 0; batchIndex < threadBatches.length; batchIndex++) {
+      const batch = threadBatches[batchIndex];
+
+      // Process all threads in this batch concurrently
+      const batchPromises = batch.map(async (thread) => {
+        try {
+          // Find InquiryResponse that references this thread
+          const inquiryResponse = await InquiryResponse.findOne({ 
+            threadId: thread._id 
+          });
+
+          if (!inquiryResponse) {
+            // No InquiryResponse found - this thread is not related to any inquiry
+            // This is normal for threads from agent playground, etc.
+            result.skippedThreads++;
+            return { type: 'skipped', threadId: thread._id };
+          }
+
+          // Find Inquiry that contains this response
+          const inquiry = await Inquiry.findOne({
+            responses: inquiryResponse._id
+          });
+
+          if (!inquiry) {
+            // InquiryResponse exists but no Inquiry contains it - data inconsistency
+            const errorMessage = `InquiryResponse ${inquiryResponse._id} found for thread ${thread._id} but no Inquiry contains this response`;
+            result.errors.push(errorMessage);
+            return { type: 'error', threadId: thread._id, error: errorMessage };
+          }
+
+          result.threadsWithInquiryResponses++;
+
+          if (dryRun) {
+            // Track the potential migration by inquiry title for dry run
+            const inquiryTitle = inquiry.data?.settings?.title || 'Untitled';
+            if (!result.migrationsByInquiry[inquiryTitle]) {
+              result.migrationsByInquiry[inquiryTitle] = 0;
+            }
+            result.migrationsByInquiry[inquiryTitle]++;
+
+            return { 
+              type: 'dry-run', 
+              threadId: thread._id, 
+              inquiryId: inquiry._id,
+              inquiryTitle: inquiry.data?.settings?.title || 'Untitled'
+            };
+          } else {
+            // Perform the actual migration
+            await Thread.updateOne(
+              { _id: thread._id },
+              { $set: { inquiryId: inquiry._id.toString() } }
+            );
+
+            // Track the migration by inquiry title
+            const inquiryTitle = inquiry.data?.settings?.title || 'Untitled';
+            if (!result.migrationsByInquiry[inquiryTitle]) {
+              result.migrationsByInquiry[inquiryTitle] = 0;
+            }
+            result.migrationsByInquiry[inquiryTitle]++;
+
+            result.successfulMigrations++;
+            
+            return { 
+              type: 'migrated', 
+              threadId: thread._id, 
+              inquiryId: inquiry._id,
+              inquiryTitle: inquiry.data?.settings?.title || 'Untitled'
+            };
+          }
+
+        } catch (error) {
+          const errorMessage = `Error processing thread ${thread._id}: ${error instanceof Error ? error.message : 'Unknown error'}`;
+          result.errors.push(errorMessage);
+          return { type: 'error', threadId: thread._id, error: errorMessage };
+        }
+      });
+
+      // Wait for all threads in this batch to complete
+      await Promise.all(batchPromises);
+    }
+
+    // Step 3: Validation (if not dry run)
+    if (!dryRun && result.successfulMigrations > 0) {
+      // Verify the migrations were successful
+      const remainingThreadsWithMissingInquiryId = await Thread.countDocuments({
+        $or: [
+          { inquiryId: { $exists: false } },
+          { inquiryId: null },
+          { inquiryId: undefined }
+        ]
+      });
+    }
+
+    // Final summary
+    log.info({
+      message: 'Migration completed',
+      dryRun,
+      result
+    });
+
+    // Display inquiry-specific summary
+    if (Object.keys(result.migrationsByInquiry).length > 0) {
+      log.info({
+        message: 'Migrations by inquiry title',
+        migrationsByInquiry: result.migrationsByInquiry
+      });
+    }
+
+    return result;
+
+  } catch (error) {
+    const errorMessage = `Migration failed: ${error instanceof Error ? error.message : 'Unknown error'}`;
+    result.errors.push(errorMessage);
+    log.error({
+      message: 'Migration failed with critical error',
+      error: errorMessage
+    });
+    throw error;
+  }
+}
+
+/**
+ * Validates the current state of thread-inquiry relationships
+ * Useful for understanding the data before and after migration
+ */
+export async function validateThreadInquiryRelationships(): Promise<{
+  totalThreads: number;
+  threadsWithInquiryId: number;
+  threadsWithMissingInquiryId: number;
+  threadsWithInquiryResponses: number;
+  orphanedThreads: number;
+  inconsistentRelationships: string[];
+}> {
+  const totalThreads = await Thread.countDocuments();
+  
+  const threadsWithInquiryId = await Thread.countDocuments({
+    inquiryId: { $exists: true, $ne: null }
+  });
+
+  const threadsWithMissingInquiryId = await Thread.countDocuments({
+    $or: [
+      { inquiryId: { $exists: false } },
+      { inquiryId: null },
+      { inquiryId: undefined }
+    ]
+  });
+
+  // Count threads that have InquiryResponse relationships but missing inquiryId
+  const threadsWithResponses = await Thread.aggregate([
+    {
+      $match: {
+        $or: [
+          { inquiryId: { $exists: false } },
+          { inquiryId: null },
+          { inquiryId: undefined }
+        ]
+      }
+    },
+    {
+      $lookup: {
+        from: 'inquiryresponses',
+        localField: '_id',
+        foreignField: 'threadId',
+        as: 'responses'
+      }
+    },
+    {
+      $match: {
+        'responses.0': { $exists: true }
+      }
+    },
+    {
+      $count: 'threadsWithInquiryResponses'
+    }
+  ]);
+
+  const threadsWithInquiryResponses = threadsWithResponses[0]?.threadsWithInquiryResponses || 0;
+  const orphanedThreads = threadsWithMissingInquiryId - threadsWithInquiryResponses;
+
+  // Check for inconsistent relationships
+  const inconsistentRelationships: string[] = [];
+
+  // Find threads with inquiryId that don't match their InquiryResponse relationships
+  const threadsWithPossibleInconsistencies = await Thread.aggregate([
+    {
+      $match: {
+        inquiryId: { $exists: true, $ne: null }
+      }
+    },
+    {
+      $lookup: {
+        from: 'inquiryresponses',
+        localField: '_id',
+        foreignField: 'threadId',
+        as: 'responses'
+      }
+    },
+    {
+      $lookup: {
+        from: 'inquiries',
+        localField: 'responses._id',
+        foreignField: 'responses',
+        as: 'inquiries'
+      }
+    },
+    {
+      $match: {
+        $expr: {
+          $and: [
+            { $gt: [{ $size: '$responses' }, 0] },
+            { $gt: [{ $size: '$inquiries' }, 0] },
+            { $ne: ['$inquiryId', { $toString: { $arrayElemAt: ['$inquiries._id', 0] } }] }
+          ]
+        }
+      }
+    }
+  ]);
+
+  for (const thread of threadsWithPossibleInconsistencies) {
+    inconsistentRelationships.push(
+      `Thread ${thread._id} has inquiryId ${thread.inquiryId} but InquiryResponse points to inquiry ${thread.inquiries[0]?._id}`
+    );
+  }
+
+  return {
+    totalThreads,
+    threadsWithInquiryId,
+    threadsWithMissingInquiryId,
+    threadsWithInquiryResponses,
+    orphanedThreads,
+    inconsistentRelationships
+  };
+}
+
+// CLI runner function for standalone execution
+export async function runMigration() {
+  try {
+    await database.init();
+    
+    // First, validate current state
+    console.log('=== Current State Validation ===');
+    const validation = await validateThreadInquiryRelationships();
+    console.log(JSON.stringify(validation, null, 2));
+
+    // Run dry run first
+    console.log('\n=== Dry Run Migration ===');
+    const dryRunResult = await migrateInquiryThreads(true);
+    console.log(JSON.stringify(dryRunResult, null, 2));
+
+    // Display inquiry breakdown in a readable format
+    if (Object.keys(dryRunResult.migrationsByInquiry).length > 0) {
+      console.log('\n📊 Threads to migrate by inquiry:');
+      const sortedInquiries = Object.entries(dryRunResult.migrationsByInquiry)
+        .sort(([,a], [,b]) => b - a); // Sort by count descending
+      
+      for (const [title, count] of sortedInquiries) {
+        console.log(`  • ${title}: ${count} thread${count === 1 ? '' : 's'}`);
+      }
+    }
+
+    // Ask for confirmation before actual migration
+    if (dryRunResult.threadsWithInquiryResponses > 0) {
+      console.log(`\n⚠️  Migration would update ${dryRunResult.threadsWithInquiryResponses} threads`);
+      console.log('To run the actual migration, call migrateInquiryThreads(false)');
+    } else {
+      console.log('\n✅ No threads found that need migration');
+    }
+
+  } catch (error) {
+    console.error('Migration failed:', error);
+    process.exit(1);
+  }
+}
+
+// Auto-run if this file is executed directly
+if (require.main === module) {
+  runMigration();
+}


### PR DESCRIPTION
## Description 📝

For inquiries created before token usage tracking was introduced, this PR performs deterministic reasoning to apply token usage to those inquiries, tracking how different users/organizations are using the demo application. Additionally, a new workflow is introduced to run database scripts against the environments' databases without needing to leave GitHub or perform it manually to reduce the likelihood of error.

## How Has This Been Tested? 🔍

- `SCRIPT=seed/migrate-inquiry-threads pnpm run db:script` was tested against a local development database with expected results.
- A dry run will be performed prior to running the scripts in production to determine if the results are satisfactory.

## Motivation and Context 🎯
How many tokens has each inquiry used